### PR TITLE
Use proto2 syntax

### DIFF
--- a/pb/rpc.proto
+++ b/pb/rpc.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package floodsub.pb;
 
 message RPC {


### PR DESCRIPTION
Resolves warning outlined in #85
